### PR TITLE
Feature/ot115 34 and 35 slides api integration and error handling

### DIFF
--- a/app/src/main/java/com/alkemy/ongandroid/businesslogic/api/OngApiService.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/businesslogic/api/OngApiService.kt
@@ -21,4 +21,7 @@ interface OngApiService{
 
     @GET("testimonials")
     suspend fun getTestimonials(): ApiTestimonialsResponse
+
+    @GET("slides")
+    suspend fun getSlides(): ApiSlidesResponse
 }

--- a/app/src/main/java/com/alkemy/ongandroid/businesslogic/repositories/ApiRepo.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/businesslogic/repositories/ApiRepo.kt
@@ -1,10 +1,12 @@
 package com.alkemy.ongandroid.businesslogic.repositories
 
 import com.alkemy.ongandroid.model.ApiNewsResponse
+import com.alkemy.ongandroid.model.ApiSlidesResponse
 import com.alkemy.ongandroid.model.ApiTestimonialsResponse
 
 interface ApiRepo {
 
     suspend fun getNews(): ApiNewsResponse
     suspend fun getTestimonials(): ApiTestimonialsResponse
+    suspend fun getSlides(): ApiSlidesResponse
 }

--- a/app/src/main/java/com/alkemy/ongandroid/businesslogic/repositories/ApiRepoImpl.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/businesslogic/repositories/ApiRepoImpl.kt
@@ -2,6 +2,7 @@ package com.alkemy.ongandroid.businesslogic.repositories
 
 import com.alkemy.ongandroid.businesslogic.api.OngApiService
 import com.alkemy.ongandroid.model.ApiNewsResponse
+import com.alkemy.ongandroid.model.ApiSlidesResponse
 import com.alkemy.ongandroid.model.ApiTestimonialsResponse
 import javax.inject.Inject
 
@@ -9,4 +10,5 @@ class ApiRepoImpl @Inject constructor (private val apiService : OngApiService) :
 
     override suspend fun getNews(): ApiNewsResponse = apiService.getNews()
     override suspend fun getTestimonials(): ApiTestimonialsResponse = apiService.getTestimonials()
+    override suspend fun getSlides(): ApiSlidesResponse = apiService.getSlides()
 }

--- a/app/src/main/java/com/alkemy/ongandroid/model/ApiSlidesResponse.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/model/ApiSlidesResponse.kt
@@ -1,0 +1,9 @@
+package com.alkemy.ongandroid.model
+
+import com.google.gson.annotations.SerializedName
+
+data class ApiSlidesResponse(
+        val success: Boolean,
+        @SerializedName("data")
+        val slideList: List<Slide>
+)

--- a/app/src/main/java/com/alkemy/ongandroid/model/Slide.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/model/Slide.kt
@@ -1,0 +1,10 @@
+package com.alkemy.ongandroid.model
+
+import com.google.gson.annotations.SerializedName
+
+data class Slide(
+        val name: String,
+        val description: String,
+        @SerializedName("image")
+        val imageUrl: String
+)

--- a/app/src/main/java/com/alkemy/ongandroid/view/adapters/WelcomeViewPagerAdapter.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/view/adapters/WelcomeViewPagerAdapter.kt
@@ -4,9 +4,10 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.alkemy.ongandroid.databinding.WelcomeViewPagerItemBinding
+import com.alkemy.ongandroid.model.Slide
 import com.bumptech.glide.Glide
 
-class WelcomeViewPagerAdapter(private val listPhotos: List<Int>) : RecyclerView.Adapter<WelcomeViewPagerAdapter.ViewHolder>() {
+class WelcomeViewPagerAdapter(private val slideList: List<Slide>) : RecyclerView.Adapter<WelcomeViewPagerAdapter.ViewHolder>() {
 
     private lateinit var binding: WelcomeViewPagerItemBinding
 
@@ -18,12 +19,15 @@ class WelcomeViewPagerAdapter(private val listPhotos: List<Int>) : RecyclerView.
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        if (listPhotos.isNotEmpty())
+        if (slideList.isNotEmpty())
         {
-            binding.txtTitlePhoto.text = holder.itemView.context.resources.getResourceEntryName(listPhotos[position % listPhotos.size])
-            Glide.with(holder.itemView.context)
-                .load(listPhotos[position % listPhotos.size])
-                .into(binding.imgPhoto)
+            with(slideList.get(position % slideList.size)){
+                binding.txtName.text = name
+                binding.txtDescription.text = description
+                Glide.with(holder.itemView.context)
+                        .load(imageUrl)
+                        .into(binding.imgPhoto)
+            }
         }
     }
 

--- a/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
@@ -74,7 +74,7 @@ class WelcomeFragment : Fragment() {
             val builder = AlertDialog.Builder(it)
             builder.apply {
                 setMessage(R.string.api_error_message)
-                setPositiveButton(R.string.api_call_error_button){dialog, _ ->
+                setPositiveButton(R.string.btn_text_try_again){dialog, _ ->
                     (activity as BaseActivity).setCustomProgressBarVisibility(true)
                     viewModel.getSlides()
                     dialog.dismiss()

--- a/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.viewpager2.widget.ViewPager2
 import com.alkemy.ongandroid.view.adapters.WelcomeViewPagerAdapter
 import com.alkemy.ongandroid.databinding.FragmentWelcomeBinding
+import com.alkemy.ongandroid.model.Slide
 import com.alkemy.ongandroid.viewmodel.WelcomeViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -32,7 +33,7 @@ class WelcomeFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        loadWelcomeImages()
+        loadSlides()
         setUpObservers()
         changeCurrentItem()
         onNewItemSelected()
@@ -48,14 +49,14 @@ class WelcomeFragment : Fragment() {
         handler.postDelayed(runnable, timeDelayAutoScrolling)
     }
 
-    private fun loadWelcomeImages()
+    private fun loadSlides()
     {
-        viewModel.getWelcomeImages()
+        viewModel.getSlides()
     }
 
-    private fun loadViewPagerAdapter(listImages: List<Int>)
+    private fun loadViewPagerAdapter(slideList: List<Slide>)
     {
-        adapter = WelcomeViewPagerAdapter(listImages)
+        adapter = WelcomeViewPagerAdapter(slideList)
         binding.vpWelcome.adapter = adapter
     }
 
@@ -79,9 +80,9 @@ class WelcomeFragment : Fragment() {
 
     private fun setUpObservers()
     {
-        viewModel.welcomeImages.observe(viewLifecycleOwner, {
+        viewModel.slideList.observe(viewLifecycleOwner, {
             when (it) {
-                is WelcomeViewModel.WelcomeImages.Success -> loadViewPagerAdapter(it.listWelcomeImages)
+                is WelcomeViewModel.SlideStatus.Success -> loadViewPagerAdapter(it.slideList)
             }
         })
     }

--- a/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
@@ -15,6 +15,7 @@ import com.alkemy.ongandroid.databinding.FragmentWelcomeBinding
 import com.alkemy.ongandroid.model.Slide
 import com.alkemy.ongandroid.view.activities.BaseActivity
 import com.alkemy.ongandroid.viewmodel.WelcomeViewModel
+import com.google.android.material.navigation.NavigationView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -73,7 +74,7 @@ class WelcomeFragment : Fragment() {
             val builder = AlertDialog.Builder(it)
             builder.apply {
                 setMessage(R.string.api_error_message)
-                setPositiveButton(R.string.api_call_error_button){dialog, id ->
+                setPositiveButton(R.string.api_call_error_button){dialog, _ ->
                     (activity as BaseActivity).setCustomProgressBarVisibility(true)
                     viewModel.getSlides()
                     dialog.dismiss()
@@ -106,7 +107,13 @@ class WelcomeFragment : Fragment() {
     {
         viewModel.slideList.observe(viewLifecycleOwner, {
             when (it) {
-                is WelcomeViewModel.SlideStatus.Success -> loadViewPagerAdapter(it.slideList)
+                is WelcomeViewModel.SlideStatus.Success -> {
+                    if (it.slideList.isEmpty()) {
+                        activity?.findViewById<NavigationView>(R.id.navView)?.menu?.removeItem(R.id.welcome)
+                    } else {
+                        loadViewPagerAdapter(it.slideList)
+                    }
+                }
                 is WelcomeViewModel.SlideStatus.Failure -> handleError()
             }
         })

--- a/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/view/fragments/WelcomeFragment.kt
@@ -56,7 +56,6 @@ class WelcomeFragment : Fragment() {
 
     private fun loadSlides()
     {
-        (activity as BaseActivity).setCustomProgressBarVisibility(true)
         viewModel.getSlides()
     }
 
@@ -64,18 +63,15 @@ class WelcomeFragment : Fragment() {
     {
         adapter = WelcomeViewPagerAdapter(slideList)
         binding.vpWelcome.adapter = adapter
-        (activity as BaseActivity).setCustomProgressBarVisibility(false)
     }
 
     private fun handleError(){
-        (activity as BaseActivity).setCustomProgressBarVisibility(false)
 
         val alertDialog: AlertDialog = activity.let {
             val builder = AlertDialog.Builder(it)
             builder.apply {
                 setMessage(R.string.api_error_message)
                 setPositiveButton(R.string.btn_text_try_again){dialog, _ ->
-                    (activity as BaseActivity).setCustomProgressBarVisibility(true)
                     viewModel.getSlides()
                     dialog.dismiss()
                 }
@@ -115,6 +111,7 @@ class WelcomeFragment : Fragment() {
                     }
                 }
                 is WelcomeViewModel.SlideStatus.Failure -> handleError()
+                is WelcomeViewModel.SlideStatus.Loading -> (activity as BaseActivity).setCustomProgressBarVisibility(it.isLoading)
             }
         })
     }

--- a/app/src/main/java/com/alkemy/ongandroid/viewmodel/WelcomeViewModel.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/viewmodel/WelcomeViewModel.kt
@@ -3,22 +3,39 @@ package com.alkemy.ongandroid.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.alkemy.ongandroid.businesslogic.repositories.WelcomeImagesRepository
+import androidx.lifecycle.viewModelScope
+import com.alkemy.ongandroid.businesslogic.repositories.ApiRepoImpl
+import com.alkemy.ongandroid.model.Slide
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WelcomeViewModel @Inject constructor(private val repository: WelcomeImagesRepository) : ViewModel() {
-    sealed class WelcomeImages {
-        class Success(val listWelcomeImages: List<Int>) : WelcomeImages()
+class WelcomeViewModel @Inject constructor(private val repository: ApiRepoImpl) : ViewModel() {
+    sealed class SlideStatus {
+        class Success(val slideList: List<Slide>) : SlideStatus()
+        class Failure(val error: Throwable) : SlideStatus()
     }
 
-    private val _welcomeImages = MutableLiveData<WelcomeImages>()
-    val welcomeImages: LiveData<WelcomeImages>
-        get() = _welcomeImages
+    private val _slideList = MutableLiveData<SlideStatus>()
+    val slideList: LiveData<SlideStatus>
+        get() = _slideList
 
-    fun getWelcomeImages()
+    fun getSlides()
     {
-        _welcomeImages.value = WelcomeImages.Success(repository.getImages())
+        viewModelScope.launch {
+            try {
+                val response = repository.getSlides()
+                if (response.success){
+                    _slideList.value = SlideStatus.Success(response.slideList)
+                } else{
+                    _slideList.value = SlideStatus.Success(emptyList())
+                }
+            }catch (err: Throwable){
+                _slideList.value = SlideStatus.Failure(err)
+            }
+
+        }
+
     }
 }

--- a/app/src/main/java/com/alkemy/ongandroid/viewmodel/WelcomeViewModel.kt
+++ b/app/src/main/java/com/alkemy/ongandroid/viewmodel/WelcomeViewModel.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WelcomeViewModel @Inject constructor(private val repository: ApiRepoImpl) : ViewModel() {
     sealed class SlideStatus {
+        class Loading(val isLoading: Boolean): SlideStatus()
         class Success(val slideList: List<Slide>) : SlideStatus()
         class Failure(val error: Throwable) : SlideStatus()
     }
@@ -23,6 +24,7 @@ class WelcomeViewModel @Inject constructor(private val repository: ApiRepoImpl) 
 
     fun getSlides()
     {
+        _slideList.value = SlideStatus.Loading(true)
         viewModelScope.launch {
             try {
                 val response = repository.getSlides()
@@ -33,6 +35,8 @@ class WelcomeViewModel @Inject constructor(private val repository: ApiRepoImpl) 
                 }
             }catch (err: Throwable){
                 _slideList.value = SlideStatus.Failure(err)
+            }finally {
+                _slideList.value = SlideStatus.Loading(false)
             }
 
         }

--- a/app/src/main/res/layout/welcome_view_pager_item.xml
+++ b/app/src/main/res/layout/welcome_view_pager_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -12,9 +13,20 @@
         app:srcCompat="@drawable/foto1" />
 
     <TextView
-        android:id="@+id/txtTitlePhoto"
+        android:id="@+id/txt_name"
         style="@style/TitleFormStyle"
         android:layout_gravity="bottom"
         android:background="@android:color/darker_gray"
-        android:text="@tools:sample/lorem" />
-</FrameLayout>
+        android:text="@tools:sample/lorem"
+        app:layout_constraintBottom_toTopOf="@+id/txt_description"
+        tools:ignore="MissingConstraints" />
+
+    <TextView
+        android:id="@+id/txt_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:background="@android:color/darker_gray"
+        android:text="@tools:sample/lorem"
+        app:layout_constraintBottom_toBottomOf="@+id/imgPhoto" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,6 @@
     <string name="user_success_sign_up">User was successfully register</string>
 
     <string name="api_error_message">Ha ocurrido un error obteniendo la información</string>
-    <string name="api_call_error_button">Reintentar</string>
 
     <string name="timer_message">Timer has finished</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="user_success_sign_up">User was successfully register</string>
 
     <string name="api_error_message">Ha ocurrido un error obteniendo la información</string>
+    <string name="api_call_error_button">Reintentar</string>
 
     <string name="timer_message">Timer has finished</string>
 


### PR DESCRIPTION
## Soluciona [Integración de la lista de slides](https://alkemy-labs.atlassian.net/browse/OT115-34) y [Mostrar mensaje de error en caso de que falle la consulta a la API](https://alkemy-labs.atlassian.net/browse/OT115-35)

### Cambios
- Creación de modelo para los datos del slide y para la respuesta de la api
- Se agregaron los métodos correspondientes para hacer la llamada a la API
- Se renombraron algunas funciones para que tengan sentido con lo que hacen
- Se implemento un dialog en caso de que la llamada a la api falle
- En caso de que la api regrese una lista vacía ase oculta la sección

### Pruebas
Así funciona normalmente
![image](https://user-images.githubusercontent.com/77474094/145499172-171ec3f4-f4cf-44bf-b47b-05dc25e488b8.png)

En caso de que regrese la lista vacía el apartado bienvenidos se oculta
![image](https://user-images.githubusercontent.com/77474094/145499267-86d435c3-7e07-44be-a73f-bec02f604f4c.png)

En caso de algún error en la petición nos muestra un mensaje y el botón para reintentar la llamada
![image](https://user-images.githubusercontent.com/77474094/145499515-34568388-6339-4461-8a46-7d592084c314.png)

